### PR TITLE
Ignore headers with null or undefined value

### DIFF
--- a/hapi-plugin-header.js
+++ b/hapi-plugin-header.js
@@ -44,9 +44,16 @@ const register = async (server, options) => {
             let value = options[name]
             if (typeof value === "function")
                 value = value(server, request, h)
-            if (typeof value === "object" && typeof value.then === "function")
+            if (
+                typeof value === "object"
+                && value != null
+                && typeof value.then === "function"
+            ) {
                 value = await value
-            setHeader(request, name, value)
+            }
+            if (typeof value === "string") {
+                setHeader(request, name, value)
+            }
         }
         return h.continue
     })

--- a/test.js
+++ b/test.js
@@ -18,7 +18,13 @@ const Request    = require("request-promise")
             "X-External-IP": (server, request, h) => {
                 return Request.get("http://myexternalip.com/raw")
                     .then((value) => value.replace(/\r?\n/g, ""))
-            }
+            },
+            "X-Null": null,
+            "X-Undefined": undefined,
+            "X-Null-Function": () => null,
+            "X-Undefined-Function": () => undefined,
+            "X-Null-Promise": async () => null,
+            "X-Undefined-Promise": async () => undefined,
         }
     })
 


### PR DESCRIPTION
This helps when we sometimes don't want to set the header.